### PR TITLE
buffer encode bug fixed

### DIFF
--- a/lib/api_common.js
+++ b/lib/api_common.js
@@ -114,7 +114,7 @@ API.prototype.request = function* (url, opts, retry) {
     throw err;
   }
 
-  var buffer = yield httpx.read(res, 'utf8');
+  var buffer = yield httpx.read(res);
   var contentType = res.headers['content-type'] || '';
   if (contentType.indexOf('application/json') !== -1) {
     var data;


### PR DESCRIPTION
buffer 默认不应该设置 encode 为 utf8 ，因为如果是图片的 buffer 是不能设置 encode 的

> PS: `JSON.parse` 支持 buffer 的，且 encode 默认是 utf8