### PR TITLE
Fix upload material shortcuts

### DIFF
--- a/lib/api_material.js
+++ b/lib/api_material.js
@@ -42,8 +42,8 @@ exports.uploadMaterial = async function (filepath, type) {
 
 ['image', 'voice', 'thumb'].forEach(function (type) {
   var method = 'upload' + type[0].toUpperCase() + type.substring(1) + 'Material';
-  exports[method] = function (filepath) {
-    this.uploadMaterial(filepath, type);
+  exports[method] = async function (filepath) {
+    return this.uploadMaterial(filepath, type);
   };
 });
 

--- a/test/api_common.test.js
+++ b/test/api_common.test.js
@@ -36,13 +36,25 @@ describe('api_common', function () {
       expect(token).to.only.have.keys('accessToken', 'expireTime');
     });
 
-    it('should not ok', async function () {
+    it('should not ok with invalid appid', async function () {
       var api = new API('appid', 'secret');
       try {
         await api.getAccessToken();
       } catch (err) {
         expect(err).to.have.property('name', 'WeChatAPIError');
-        expect(err).to.have.property('message', 'invalid credential');
+        expect(err).to.have.property('message');
+        expect(err.message).to.match(/invalid appid/);
+      }
+    });
+
+    it('should not ok with invalid appsecret', async function () {
+      var api = new API(config.appid, 'appsecret');
+      try {
+        await api.getAccessToken();
+      } catch (err) {
+        expect(err).to.have.property('name', 'WeChatAPIError');
+        expect(err).to.have.property('message');
+        expect(err.message).to.match(/invalid appsecret/);
       }
     });
   });


### PR DESCRIPTION
The shortcuts `uploadImageMaterial`, `uploadVoiceMaterial` and `uploadThumbMaterial` should be asynchronous functions too.