### PR TITLE
fix lang bug

### DIFF
--- a/lib/api_user.js
+++ b/lib/api_user.js
@@ -79,7 +79,7 @@ exports.batchGetUsers = async function (openids) {
   var url = this.prefix + 'user/info/batchget?access_token=' + accessToken;
   var data = {};
   data.user_list = openids.map(function (openid) {
-    return {openid: openid, lang: 'zh-CN'};
+    return {openid: openid, lang: 'zh_CN'};
   });
   return this.request(url, postJSON(data));
 };


### PR DESCRIPTION
return {openid: openid, lang: 'zh_CN'};

经过测试，只有为'zh_CN'才可以返回中文信息。