### PR TITLE
修复url中反斜杠转义错误

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -17,7 +17,7 @@ exports.postJSON = function (data) {
 
 const JSONCtlCharsMap = {
   '"': '\\"',       // \u0022
-  // '\\': '\\\\',     // \u005c
+  '\\': '\\',       // \u005c
   '\b': '\\b',      // \u0008
   '\f': '\\f',      // \u000c
   '\n': '\\n',      // \u000a


### PR DESCRIPTION
'\\': '\\\\'
改写成
'\\': '\\'