### PR TITLE
修复小程序 template URL

### DIFF
--- a/lib/api_template.js
+++ b/lib/api_template.js
@@ -77,6 +77,7 @@ exports.sendTemplate = async function (openid, templateId, url, topColor, data, 
 
 /**
  * 发送模板消息支持小程序
+ * 文档：https://developers.weixin.qq.com/miniprogram/dev/api/notice.html
  * Examples:
  * ```
  * var templateId = '模板id';
@@ -103,7 +104,7 @@ exports.sendTemplate = async function (openid, templateId, url, topColor, data, 
  */
 exports.sendMiniProgramTemplate = async function (openid, templateId, url, appid, pagepath, data, color) {
   const { accessToken } = await this.ensureAccessToken();
-  var apiUrl = this.prefix + 'message/template/send?access_token=' + accessToken;
+  var apiUrl = this.prefix + 'message/wxopen/template/send?access_token=' + accessToken;
   var template = {
     touser: openid,
     template_id: templateId,


### PR DESCRIPTION
微信报错：
`"errmsg":"api unauthorized`