### PR TITLE
JSON.parse 微信返回数据之后超长数字精度丢失问题解决

### DIFF
--- a/lib/api_common.js
+++ b/lib/api_common.js
@@ -3,6 +3,7 @@
 // 本文件用于wechat API，基础文件，主要用于Token的处理和mixin机制
 const httpx = require('httpx');
 const liburl = require('url');
+const JSONbig = require('json-bigint');
 const {
   replaceJSONCtlChars
 } = require('./util');
@@ -129,7 +130,7 @@ class API {
       var data;
       var origin = buffer.toString();
       try {
-        data = JSON.parse(replaceJSONCtlChars(origin));
+        data = JSONbig.parse(replaceJSONCtlChars(origin));
       } catch (ex) {
         let err = new Error('JSON.parse error. buffer is ' + origin);
         err.name = 'WeChatAPIError';

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   ],
   "dependencies": {
     "formstream": ">=0.0.8",
-    "httpx": "^2.1.1"
+    "httpx": "^2.1.1",
+    "json-bigint": "^0.2.3"
   },
   "devDependencies": {
     "coveralls": "*",


### PR DESCRIPTION
在sendTemplate等某些接口返回值中会包含超长数字（正负2的53次方），使用json-bigint库替换JSON.parse可以正常解析该超长值