### PR TITLE
fix the usage of httpx in api.setKfAccountAvatar

### DIFF
--- a/lib/api_custom_service.js
+++ b/lib/api_custom_service.js
@@ -263,14 +263,14 @@ exports.setKfAccountAvatar = async function (account, filepath) {
   var stat = await statAsync(filepath);
   var form = formstream();
   form.file('media', filepath, path.basename(filepath), stat.size);
-  var prefix = 'http://api.weixin.qq.com/';
+  var prefix = 'https://api.weixin.qq.com/';
   var url = prefix + 'customservice/kfaccount/uploadheadimg?access_token=' + accessToken + '&kf_account=' + account;
   var opts = {
     dataType: 'json',
     method: 'POST',
     timeout: 60000, // 60秒超时
     headers: form.headers(),
-    stream: form
+    data: form
   };
   return this.request(url, opts);
 };


### PR DESCRIPTION
the usage of httpx in api.setKfAccountAvatar is incorrent, the params "stream" in options should be "data".