### PR TITLE
fix: getJsConfig增加可选参数openTagList

### DIFF
--- a/lib/api_js.js
+++ b/lib/api_js.js
@@ -186,7 +186,7 @@ exports.getJsConfig = async function (param) {
   var timestamp = createTimestamp();
   var signature = sign(nonceStr, jsAPITicket, timestamp, param.url);
 
-  return {
+  var result = {
     debug: param.debug,
     appId: this.appid,
     timestamp: timestamp,
@@ -194,6 +194,12 @@ exports.getJsConfig = async function (param) {
     signature: signature,
     jsApiList: param.jsApiList
   };
+
+  if (param.openTagList) {
+    result.openTagList = param.openTagList;
+  }
+
+  return result;
 };
 
 /**


### PR DESCRIPTION
getJsConfig增加可选参数openTagList，见新版微信文档：https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_Open_Tag.html